### PR TITLE
Add AlphaEvolve links and GitHub Pages instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,19 @@
 # feed
+
+This repository demonstrates a minimal GitHub Pages site that publishes an RSS feed. The sample entry references DeepMind's AlphaEvolve project.
+
+AlphaEvolve PDF: https://storage.googleapis.com/deepmind-media/DeepMind.com/Blog/alphaevolve-a-gemini-powered-coding-agent-for-designing-advanced-algorithms/AlphaEvolve.pdf
+Blog post: https://deepmind.google/discover/blog/alphaevolve-a-gemini-powered-coding-agent-for-designing-advanced-algorithms/
+Repository: https://github.com/BenjaminNowak/feed
+
+## Viewing the RSS feed
+
+Once GitHub Pages is enabled, navigate to `https://<username>.github.io/<repository>/feed.xml` (replace `<username>` and `<repository>` with your values) to see the RSS output. The site includes a basic `index.html` page that links to the feed.
+
+## Enabling GitHub Pages
+
+1. Open the repository on GitHub and go to **Settings**.
+2. Select **Pages** from the left sidebar.
+3. Under **Build and deployment**, choose the branch (e.g., `main`) and the folder (usually `/root` or `/docs`).
+4. Click **Save**. GitHub will provide a link to your published site in a few moments.
+

--- a/feed.xml
+++ b/feed.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0">
+  <channel>
+    <title>Feed</title>
+    <description>Sample feed about AlphaEvolve</description>
+    <link>https://github.com/BenjaminNowak/feed</link>
+    <lastBuildDate>Mon, 01 Jan 2024 00:00:00 +0000</lastBuildDate>
+    <item>
+      <title>AlphaEvolve - a Gemini-powered coding agent</title>
+      <description>DeepMind's AlphaEvolve project explores algorithm design with Gemini. PDF: https://storage.googleapis.com/deepmind-media/DeepMind.com/Blog/alphaevolve-a-gemini-powered-coding-agent-for-designing-advanced-algorithms/AlphaEvolve.pdf</description>
+      <link>https://deepmind.google/discover/blog/alphaevolve-a-gemini-powered-coding-agent-for-designing-advanced-algorithms/</link>
+      <pubDate>Mon, 01 Jan 2024 00:00:00 +0000</pubDate>
+      <guid>alphaevolve</guid>
+    </item>
+  </channel>
+</rss>

--- a/index.html
+++ b/index.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>Feed</title>
+    <link rel="alternate" type="application/rss+xml" title="RSS" href="feed.xml">
+</head>
+<body>
+    <h1>Feed</h1>
+    <p>This repository hosts a simple RSS feed with a sample story about <a href="https://deepmind.google/discover/blog/alphaevolve-a-gemini-powered-coding-agent-for-designing-advanced-algorithms/">AlphaEvolve</a>.</p>
+    <p>The PDF can be found <a href="https://storage.googleapis.com/deepmind-media/DeepMind.com/Blog/alphaevolve-a-gemini-powered-coding-agent-for-designing-advanced-algorithms/AlphaEvolve.pdf">here</a>.</p>
+    <p>View the <a href="feed.xml">RSS feed</a>.</p>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- note AlphaEvolve resources in the README
- show how to enable GitHub Pages
- link to the PDF and blog post from index.html and feed.xml

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_683c8593a26c8323bb67a6292218098d