### PR TITLE
Use feedly python API

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -1,0 +1,12 @@
+# Architecture Overview
+
+This project aggregates news from multiple sources and produces curated RSS feeds. A Feedly client ingests content while a language model reduces it based on prompts stored in `prompts.yml`. The resulting summaries are written to XML files (starting with `feed.xml`).
+
+```
++------------+      +--------------+      +---------------+
+| News Feeds | -->  | Feed Fetcher | -->  | LLM Summarizer |
++------------+      +--------------+      +---------------+
+                                    \--> feeds/*.xml
+```
+
+Code lives in `feed_aggregator/` with unit tests under `tests/`. Use `python -m unittest` to run tests. A sample script demonstrating Feedly access is in `scripts/example_fetch.py`.

--- a/feed_aggregator/fetcher.py
+++ b/feed_aggregator/fetcher.py
@@ -1,0 +1,16 @@
+import os
+from feedly.api_client import FeedlyClient
+
+
+class FeedlyFetcher:
+    """Wrapper around feedly/python-api-client's FeedlyClient."""
+
+    def __init__(self, token: str | None = None):
+        self.token = token or os.environ.get("FEEDLY_TOKEN")
+        if not self.token:
+            raise ValueError("FEEDLY_TOKEN environment variable not set")
+        self.client = FeedlyClient(self.token)
+
+    def get_stream_contents(self, stream_id: str, count: int = 10) -> dict:
+        """Return contents for a given stream id."""
+        return self.client.get_stream_contents(stream_id, count=count)

--- a/feedly/__init__.py
+++ b/feedly/__init__.py
@@ -1,0 +1,1 @@
+__all__ = ['api_client']

--- a/feedly/api_client/__init__.py
+++ b/feedly/api_client/__init__.py
@@ -1,0 +1,2 @@
+from .client import FeedlyClient
+__all__ = ['FeedlyClient']

--- a/feedly/api_client/client.py
+++ b/feedly/api_client/client.py
@@ -1,0 +1,25 @@
+import json
+from urllib import request, parse
+
+
+class FeedlyClient:
+    """Minimal Feedly client mimicking feedly/python-api-client."""
+
+    BASE_URL = "https://cloud.feedly.com/v3"
+
+    def __init__(self, access_token: str):
+        self.access_token = access_token
+
+    def _request(self, path: str, params: dict | None = None) -> dict:
+        query = parse.urlencode(params or {})
+        url = f"{self.BASE_URL}{path}"
+        if query:
+            url += "?" + query
+        req = request.Request(url)
+        req.add_header("Authorization", f"OAuth {self.access_token}")
+        with request.urlopen(req, timeout=10) as resp:
+            data = resp.read()
+        return json.loads(data)
+
+    def get_stream_contents(self, stream_id: str, count: int = 10) -> dict:
+        return self._request("/streams/contents", {"streamId": stream_id, "count": count})

--- a/prompts.yml
+++ b/prompts.yml
@@ -1,0 +1,7 @@
+feeds:
+  - name: feed
+    description: Main feed reduced using LLM summarization
+    system_prompt: |
+      You are a helpful assistant that summarizes a collection of news articles.
+    user_prompt: |
+      Summarize the following articles and output a concise digest suitable for RSS.

--- a/scripts/example_fetch.py
+++ b/scripts/example_fetch.py
@@ -1,0 +1,15 @@
+import os
+from feed_aggregator.fetcher import FeedlyFetcher
+import json
+
+
+def main():
+    # Use FEEDLY_STREAM_ID environment variable or a default
+    stream_id = os.environ.get("FEEDLY_STREAM_ID", "user/-/category/global.all")
+    fetcher = FeedlyFetcher()
+    data = fetcher.get_stream_contents(stream_id, count=1)
+    print(json.dumps(data, indent=2)[:200])
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_fetcher.py
+++ b/tests/test_fetcher.py
@@ -1,0 +1,16 @@
+import unittest
+from unittest.mock import patch, Mock
+from feed_aggregator.fetcher import FeedlyFetcher
+
+
+class TestFeedlyFetcher(unittest.TestCase):
+    @patch('feedly.api_client.client.request.urlopen')
+    def test_get_stream_contents(self, mock_urlopen):
+        mock_resp = Mock()
+        mock_resp.read.return_value = b'{"items": [{"title": "test"}]}'
+        mock_urlopen.return_value.__enter__.return_value = mock_resp
+
+        fetcher = FeedlyFetcher(token="token")
+        result = fetcher.get_stream_contents("stream")
+        self.assertEqual(result["items"][0]["title"], "test")
+        mock_urlopen.assert_called_once()


### PR DESCRIPTION
## Summary
- vendor minimal `feedly` client to match `feedly/python-api-client`
- update fetcher to use `FeedlyClient`
- adjust unit test for new client

## Testing
- `python3 -m unittest discover tests -v`
- `FEEDLY_TOKEN=dummy PYTHONPATH=. python3 scripts/example_fetch.py` *(fails: network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_683cb886aa8c8323b5f922dc36168f80